### PR TITLE
Remove trailing whitespace.

### DIFF
--- a/.github/workflows/build-pdf.yml
+++ b/.github/workflows/build-pdf.yml
@@ -86,7 +86,7 @@ jobs:
           name: hart-trace-interface${{ env.SHORT_SHA }}.html
           path: ${{ github.workspace }}/build/hart-trace-interface.html
           retention-days: 7
-          
+
       # Create Release
       - name: Create Release
         uses: softprops/action-gh-release@v1

--- a/src/contributors.adoc
+++ b/src/contributors.adoc
@@ -4,4 +4,3 @@ This RISC-V specification has been contributed to directly or indirectly by:
 
 [%hardbreaks]
 * Iain Robertson <iain.robertson@siemens.com> - author
-

--- a/src/hart-trace-interface.adoc
+++ b/src/hart-trace-interface.adoc
@@ -66,5 +66,3 @@ include::contributors.adoc[]
 
 include::intro.adoc[]
 include::hti.adoc[]
-
-

--- a/src/hart-trace-interface.adoc
+++ b/src/hart-trace-interface.adoc
@@ -60,7 +60,7 @@ Copyright 2025 by RISC-V International.
 [colophon]
 
 *_Preface to Version TBD_*
-Chapter 2 of this document is identical in content to Chapter 4 of *Version 20250616* of the https://github.com/riscv-non-isa/riscv-trace-spec/releases/latest/[Efficient Trace for RISC-V Specification], which is the ratified 2.0 specification with some informative clarifications and corrections.  
+Chapter 2 of this document is identical in content to Chapter 4 of *Version 20250616* of the https://github.com/riscv-non-isa/riscv-trace-spec/releases/latest/[Efficient Trace for RISC-V Specification], which is the ratified 2.0 specification with some informative clarifications and corrections.
 [preface]
 include::contributors.adoc[]
 

--- a/src/hti.adoc
+++ b/src/hti.adoc
@@ -306,9 +306,9 @@ block.
 *itype* can be 3 or 4 bits wide. If _itype_width_p_ is 3, a single code
 (6) is used to indicate all uninferable jumps. This is simpler to
 implement, but precludes use of the implicit return mode (see
-<<sec:implicit-return>>), which requires jump types to be fully classified.  
-Note that when _itype_width_p_ is 3, *itype* = 0 is used for inferrable calls.  
-However, inferrable calls must still be the last instruction retired in a 
+<<sec:implicit-return>>), which requires jump types to be fully classified.
+Note that when _itype_width_p_ is 3, *itype* = 0 is used for inferrable calls.
+However, inferrable calls must still be the last instruction retired in a
 block, otherwise the block would not be comprised of contiguous instructions.
 
 Whilst *iaddr* is typically a virtual address, it does not affect the
@@ -419,7 +419,7 @@ and OR.
 ==== Optional sideband signals
 
 Optional sideband signals may be included to provide additional
-functionality, as described in 
+functionality, as described in
 <<tab:ingress-side-band>> and
 <<tab:egress-side-band>>.
 
@@ -496,7 +496,7 @@ cycle that Trace-off is asserted (subject to any optional filtering).
 It follows from this that:
 
 *  if tracing is enabled and trace-off occurs on the cycle before trace-on, then tracing will continue unimpeded (i.e. it stays on);
-* if tracing is disabled and trace-on and trace-off triggers occur simultaneously then only the instructions retired in that cycle will be traced. 
+* if tracing is disabled and trace-on and trace-off triggers occur simultaneously then only the instructions retired in that cycle will be traced.
 
 Trace-notify provides means to ensure that a specified instruction is
 explicitly reported (subject to any optional filtering). This capability
@@ -518,7 +518,7 @@ is sometimes known as a watchpoint.
 | **iretire**=3, **iaddr**=0x0940, **itype**=4
 |0946: *_c.bnez_* | **iretire**=1, **iaddr**=0x0946, **itype**=5
 |0988: *_lbu_* +
-098C: *_csrrw_* 
+098C: *_csrrw_*
 | **iretire**=4, **iaddr**=0x0988, **itype**=0
 |===
 

--- a/src/intro.adoc
+++ b/src/intro.adoc
@@ -60,5 +60,3 @@ in the RISC-V ISA
 
 Items in _italics_ with names ending _’_p’_ refer to parameters either
 built into the hardware or configurable hardware values.
-
-


### PR DESCRIPTION
Remove trailing whitespace so that precommit GH actions doesn't fail.