### PR TITLE
7 one of the tables is breaking the gh action create specification document

### DIFF
--- a/src/hti.adoc
+++ b/src/hti.adoc
@@ -217,10 +217,10 @@ instruction is 2^*ilastsize*^ half-words.
 |*ilastsize*[_ilastsize_width_p-1_:0] | SR | The size of the last retired
 instruction in this block is 2^*ilastsize*^ half-words.
 |===
-////
+
 [[tab:itype3]]
 .Instruction Type (*itype*) encoding (_itype_width_p_ = 3)
-[align="center",float="center",cols="<,19%,<,~",options="header"]
+[%autowidth,align="center",float="center",cols="<,<,<,~",options="header"]
 |===
 | *Value* | *Name* | *Instruction* | *Condition/Notes*
 | 0 |Other | | Last instruction in the block matches none of the other instructions defined in this table
@@ -237,7 +237,7 @@ retired instruction
                   Defined by *Zcmt* extension
 |7 | reserved | |
 |===
-////
+
 [[tab:itype4]]
 .Instruction Type (*itype*) encoding (_itype_width_p_ = 4)
 [%autowidth,align="center",float="center",cols="<,<,<,<",options="header"]

--- a/src/hti.adoc
+++ b/src/hti.adoc
@@ -155,7 +155,7 @@ retire one instruction in a block. Replication as per OR (see
 BR group signals instead.
 
 "Special" instructions are those that require *itype* to be non-zero.
-////
+
 [[tab:common-ingress]]
 .Instruction interface signals
 [%autowidth,align="center",float="center",cols="<,<,<"options="header"]
@@ -188,14 +188,14 @@ sequentially inferable and may be treated as inferable by the encoder if
 the preceding *_auipc_*, *_lui_* or *_c.lui_* has been traced. Ignored
 for *itype* codes other than 6, 8, 10, 12 or 14.
 |===
-////
+
 <<tab:common-ingress>> and <<tab:multi-ingress>> list the signals in the
 interface designed to efficiently support retirement of multiple
 instructions per cycle. The following discussion describes the
 multiple-retirement behavior. However, for harts that can only retire
 one instruction at a time, the signalling can be simplified, and this is
 discussed subsequently in <<sec:single-retire>>.
-
+////
 [[tab:multi-ingress]]
 .Instruction interface signals - multiple retirement per block
 [%autowidth,align="center",float="center",cols="<,<,<",options="header"]
@@ -217,7 +217,7 @@ instruction is 2^*ilastsize*^ half-words.
 |*ilastsize*[_ilastsize_width_p-1_:0] | SR | The size of the last retired
 instruction in this block is 2^*ilastsize*^ half-words.
 |===
-
+////
 [[tab:itype3]]
 .Instruction Type (*itype*) encoding (_itype_width_p_ = 3)
 [align="center",float="center",cols="<,19%,<,~",options="header"]

--- a/src/hti.adoc
+++ b/src/hti.adoc
@@ -155,7 +155,7 @@ retire one instruction in a block. Replication as per OR (see
 BR group signals instead.
 
 "Special" instructions are those that require *itype* to be non-zero.
-
+////
 [[tab:common-ingress]]
 .Instruction interface signals
 [%autowidth,align="center",float="center",cols="<,<,<"options="header"]
@@ -188,7 +188,7 @@ sequentially inferable and may be treated as inferable by the encoder if
 the preceding *_auipc_*, *_lui_* or *_c.lui_* has been traced. Ignored
 for *itype* codes other than 6, 8, 10, 12 or 14.
 |===
-
+////
 <<tab:common-ingress>> and <<tab:multi-ingress>> list the signals in the
 interface designed to efficiently support retirement of multiple
 instructions per cycle. The following discussion describes the

--- a/src/hti.adoc
+++ b/src/hti.adoc
@@ -195,7 +195,7 @@ instructions per cycle. The following discussion describes the
 multiple-retirement behavior. However, for harts that can only retire
 one instruction at a time, the signalling can be simplified, and this is
 discussed subsequently in <<sec:single-retire>>.
-////
+
 [[tab:multi-ingress]]
 .Instruction interface signals - multiple retirement per block
 [%autowidth,align="center",float="center",cols="<,<,<",options="header"]
@@ -237,7 +237,7 @@ retired instruction
                   Defined by *Zcmt* extension
 |7 | reserved | |
 |===
-
+////
 [[tab:itype4]]
 .Instruction Type (*itype*) encoding (_itype_width_p_ = 4)
 [%autowidth,align="center",float="center",cols="<,<,<,<",options="header"]


### PR DESCRIPTION
Fixed the itype3 table so that the GH action build works again.