### PR TITLE
remove less common extra r from inferable

### DIFF
--- a/src/hti.adoc
+++ b/src/hti.adoc
@@ -260,7 +260,7 @@ retired instruction
                         C.JALR rs | rd = `link` and rs != `link` +
                                     rd = `link` and rs = `link` and rd = rs +
                                     rs != *x5*
-|9 | Inferrable call | JAL rd +
+|9 | Inferable call  | JAL rd +
                        C.JAL +
                        CM.JALT| rd = `link` +
                                 Expands to `JAL x1, offset` +
@@ -269,7 +269,7 @@ retired instruction
       (without linkage) | JALR rd, rs +
                           C.JR rs    | rd = *x0* and rs != `link` +
                                        rs != `link` +
-|11 | Inferrable jump | JAL rd +
+|11 | Inferable jump  | JAL rd +
                         C.J +
                         CM.JT| rd = *x0* +
                                Expands to `JAL x0, offset` +
@@ -332,8 +332,8 @@ block.
 (6) is used to indicate all uninferable jumps. This is simpler to
 implement, but precludes use of the implicit return mode (see
 <<impret,Implicit Return>>), which requires jump types to be fully classified.
-Note that when _itype_width_p_ is 3, *itype* = 0 is used for inferrable calls.
-However, inferrable calls must still be the last instruction retired in a
+Note that when _itype_width_p_ is 3, *itype* = 0 is used for inferable calls.
+However, inferable calls must still be the last instruction retired in a
 block, otherwise the block would not be comprised of contiguous instructions.
 
 Whilst *iaddr* is typically a virtual address, it does not affect the


### PR DESCRIPTION
used codespell to look for spelling issues and this was all it found:

```
❯ codespell -L hart 
./src/hti.adoc:263: Inferrable ==> Inferable
./src/hti.adoc:272: Inferrable ==> Inferable
./src/hti.adoc:335: inferrable ==> inferable
./src/hti.adoc:336: inferrable ==> inferable
```

This also makes it consistent with rest of usage : 

```
kbroch@kbroch-mac.local:~/rvi/repos/riscv-non-isa/hart-trace-interface on  main [?]
❯ rg -i Inferable
src/intro.adoc
36:* *inferable jump*: a jump where the target address is supplied via a
38:* *uninferable jump*: a jump which is not inferable (see above)
52:* *updiscon*: contraction of ’uninferable PC discontinuity’

src/hti.adoc
58:* Whether jump targets are sequentially inferable or not.
73:* Uninferable jumps can be treated as inferable (which don't need to be
80:Jumps are classified as _inferable_, or _uninferable_. An _inferable_
86:jump opcode, it is classified as _inferable_. Jumps which are not
87:_inferable_ are by definition _uninferable_.
91:the above definition they are classified as uninferable. Specifically,
98:Such jump targets are classified as _sequentially inferable_ if the pair
105:sequentially inferable jumps is optional.
186:uninferable discontinuity, setting this signal to 1 indicates that it is
187:sequentially inferable and may be treated as inferable by the encoder if
237:                  CM.POPRET| Uninferable jump +
258:|8 | Uninferable call | JALR rd, rs +
268:|10 | Uninferable jump +
286:|14 | Other uninferable jump (with linkage) | JALR rd, rs | rd != `link` and rd != *x0* and rs != `link` +
287:|15 | Other inferable jump (without linkage) | JAL rd | rd != `link` and rd != *x0*
298:NOTE: Jump instructions (CM.JT and CM.JALT) defined by ratified *Zcmt* extension are handled as direct (inferable) jumps as jump tables are assumed to be static and known to the decoder.
332:(6) is used to indicate all uninferable jumps. This is simpler to
359:the logic to detect sequentially inferable jumps. If the encoder offers
363:capability. Enabling sequentially inferable jump mode in the encoder and
```